### PR TITLE
Update cookieconsent.js, do not show if navigator.CookiesOK is set

### DIFF
--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -20,7 +20,7 @@
   var THEME_BUCKET_PATH = '//s3.amazonaws.com/cc.silktide.com/';
 
   // No point going further if they've already dismissed.
-  if (document.cookie.indexOf(DISMISSED_COOKIE) > -1) {
+  if (document.cookie.indexOf(DISMISSED_COOKIE) > -1 || navigator.CookiesOK) {
     return;
   }
 


### PR DESCRIPTION
If the user has installed a popular plugin such as CookiesOK to automatically accept all cookies navigator.CookiesOK will be set and the dialog should not be shown.