### PR TITLE
Added a target attribute to the cookieconsent object

### DIFF
--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -231,6 +231,7 @@
       dismiss: 'Got it!',
       learnMore: 'More info',
       link: null,
+      target: "_self",
       container: null, // selector
       theme: 'light-floating',
       domain: null, // default to current domain.
@@ -241,7 +242,7 @@
         '<div class="cc_banner cc_container cc_container--open">',
         '<a href="#null" data-cc-event="click:dismiss" target="_blank" class="cc_btn cc_btn_accept_all">{{options.dismiss}}</a>',
 
-        '<p class="cc_message">{{options.message}} <a data-cc-if="options.link" class="cc_more_info" href="{{options.link || "#null"}}">{{options.learnMore}}</a></p>',
+        '<p class="cc_message">{{options.message}} <a data-cc-if="options.link" target="{{ options.target }}" class="cc_more_info" href="{{options.link || "#null"}}">{{options.learnMore}}</a></p>',
 
         '<a class="cc_logo" target="_blank" href="http://silktide.com/cookieconsent">Cookie Consent plugin for the EU cookie law</a>',
         '</div>',


### PR DESCRIPTION
Added a target parameter to the cookieconsent default object so the 'Learn more' link can be specified as a target blank or left to be default '_self'

 