### PR TITLE
Avoid to put the token into global space (aka window) in DomBuilder::insertReplacements method

### DIFF
--- a/cookieconsent.js
+++ b/cookieconsent.js
@@ -153,7 +153,7 @@
     var insertReplacements = function (htmlStr, scope) {
       return htmlStr.replace(/\{\{(.*?)\}\}/g, function (_match, sub) {
         var tokens = sub.split('||');
-        var value;
+        var value, token;
         while (token = tokens.shift()) {
           token = token.trim();
 


### PR DESCRIPTION
I detected a problem using in a project the global variable token, as the DomBuilder::insertReplacements changes the global token var